### PR TITLE
Update config.blueos.toml for MacOS

### DIFF
--- a/config.blueos.toml
+++ b/config.blueos.toml
@@ -12,7 +12,7 @@ linker = "arm-none-eabi-gcc"
 ar = "arm-none-eabi-ar"
 ranlib = "arm-none-eabi-ranlib"
 
-[target."thumbv8m.main-vivo-blueos-newlibeabi"]
+[target."thumbv8m.main-vivo-blueos-newlibeabihf"]
 cc = "arm-none-eabi-gcc"
 cxx = "arm-none-eabi-g++"
 linker = "arm-none-eabi-gcc"


### PR DESCRIPTION
Description: Fix mac toolchain error
Reason: 
```
./x.py install -i --stage 1 library/std --target thumbv8m.main-vivo-blueos-newlibeabihf compile error on MacOS
```
Issue: NA

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
