### PR TITLE
Strip binaries to avoid exhausting runner's space

### DIFF
--- a/config.blueos.toml
+++ b/config.blueos.toml
@@ -56,6 +56,7 @@ profiler = true
 [rust]
 omit-git-hash = false
 deny-warnings = false
+strip = true
 
 [dist]
 compression-formats = ["xz"]


### PR DESCRIPTION
So that we can largely reduce artifacts' size and not exhaust github action runner's space.

Experiment was conducted in https://github.com/lawkai-vivo/test_build_toolchain/actions/runs/16689247300.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
