### PR TITLE
fix: rv32imc on BlueOS should use emutls at the moment

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv32imc_vivo_blueos.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv32imc_vivo_blueos.rs
@@ -1,4 +1,4 @@
-use crate::spec::{PanicStrategy, RelocModel, Target, TargetOptions, cvs};
+use crate::spec::{PanicStrategy, RelocModel, Target, TargetOptions, TlsModel, cvs};
 
 pub(crate) fn target() -> Target {
     Target {
@@ -16,6 +16,7 @@ pub(crate) fn target() -> Target {
             families: cvs!["unix"],
             os: "blueos".into(),
             env: "newlib".into(),
+            tls_model: TlsModel::Emulated,
             vendor: "vivo".into(),
             linker: Some("rust-lld".into()),
             cpu: "generic-rv32".into(),


### PR DESCRIPTION
Same as rv32imac on BlueOS.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
