### PR TITLE
feat: Use PIC relocation model by default

### DIFF
--- a/compiler/rustc_target/src/spec/targets/riscv64_vivo_blueos.rs
+++ b/compiler/rustc_target/src/spec/targets/riscv64_vivo_blueos.rs
@@ -29,7 +29,7 @@ pub(crate) fn target() -> Target {
             max_atomic_width: Some(64),
             features: "+m,+a,+c".into(),
             panic_strategy: PanicStrategy::Abort,
-            relocation_model: RelocModel::Static,
+            relocation_model: RelocModel::Pic,
             code_model: Some(CodeModel::Medium),
             emit_debug_gdb_scripts: false,
             eh_frame_header: false,


### PR DESCRIPTION
We need a libcore with PIC enabled to build static PIE.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
