### PR TITLE
Don't build clang to save time

### DIFF
--- a/config.blueos.toml
+++ b/config.blueos.toml
@@ -64,5 +64,4 @@ strip = true
 compression-formats = ["xz"]
 
 [llvm]
-clang = true
 download-ci-llvm = false


### PR DESCRIPTION
clang is installed via the package manager.

<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r\? <reviewer name> (with the `\` removed)
-->
<!-- homu-ignore:end -->
