### PR TITLE
fix: After upgrading Xcode, compiling libsys on macOS failed; upgrade…

### DIFF
--- a/src/tools/miri/Cargo.toml
+++ b/src/tools/miri/Cargo.toml
@@ -37,7 +37,7 @@ features = ['unprefixed_malloc_on_supported_platforms']
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-libffi = "3.2.0"
+libffi = "4.1.2"
 libloading = "0.8"
 
 [target.'cfg(target_family = "windows")'.dependencies]


### PR DESCRIPTION
see https://github.com/libffi-rs/libffi-rs/issues/109